### PR TITLE
Minor build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ hs_err_pid*
 /target/
 /output-eclipse/
 /bootstrap/
+/.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: false
+dist: trusty
+
+language: java
+jdk: oraclejdk9
+
+addons:
+  apt:
+    packages:
+      - oracle-java9-installer
+
+notifications:
+  email:
+    on_success: never
+    on_failure: always
+
+install:
+- java -version
+
+script:
+- chmod u+x ./build.sh
+- ./build.sh

--- a/build.bat
+++ b/build.bat
@@ -1,5 +1,5 @@
 @echo off
-set "JAVA_HOME=C:\Program Files\Java\jdk-9"
+if "%JAVA_HOME%" == "" set "JAVA_HOME=C:\Program Files\Java\jdk-9"
 set "java=%JAVA_HOME%\bin\java"
 set "javac=%JAVA_HOME%\bin\javac"
 

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ esac
 
 #export JAVA_HOME=/usr/jdk/jdk-9-jigsaw-b146
 # For Cygwin, ensure paths are in UNIX format before anything is touched
-export JAVA_HOME=/usr/jdk/jdk-9
+[ -z "$JAVA_HOME" ] && export JAVA_HOME=/usr/jdk/jdk-9
 
 if $darwin; then
   [ -n "$JAVA_HOME" ] && JAVA_HOME="/Library/Java/JavaVirtualMachines/jdk-9.jdk/Contents/Home/"
@@ -34,5 +34,3 @@ $javac --module-source-path src/main/java \
 
 $java --module-path bootstrap/modules:deps \
       --module com.github.forax.pro.bootstrap/com.github.forax.pro.bootstrap.Bootstrap
-      
-      


### PR DESCRIPTION
### Overview

On Windows, only override JAVA_HOME if not already set.
On Linux (and friends), only override JAVA_HOME if not already set.
On Travis, build pro.
On project root, ignore '.idea/' directory.

### TODO
- [x] squash commits
- [x] fix and use `build.sh`