### PR TITLE
Use `bin\java.exe` as executable name on Windows

### DIFF
--- a/src/main/java/com.github.forax.pro.plugin.runner/com/github/forax/pro/plugin/runner/RunnerPlugin.java
+++ b/src/main/java/com.github.forax.pro.plugin.runner/com/github/forax/pro/plugin/runner/RunnerPlugin.java
@@ -45,7 +45,14 @@ public class RunnerPlugin implements Plugin {
     runner.modulePath(StableList.of(convention.javaModuleArtifactSourcePath())
         .appendAll(convention.javaModuleDependencyPath())
         .appendAll(convention.javaModuleExplodedSourcePath()));
-    runner.javaCommand(convention.javaHome().resolve("bin/java"));   //FIXME may be java.bat ??
+    runner.javaCommand(convention.javaHome().resolve(javaExecutableName()));
+  }
+
+  private String javaExecutableName() {
+    if (System.getProperty("os.name").toLowerCase().contains("win")) {
+      return "bin\\java.exe";
+    }
+    return "bin/java";
   }
   
   @Override


### PR DESCRIPTION
Resolves the `//FIXME may be java.bat ??` issue in `RunnerPlugin.java` by using `bin\\java.exe` on Windows systems.