### PR TITLE
run() twice

### DIFF
--- a/src/main/java/com.github.forax.pro.bootstrap/com/github/forax/pro/bootstrap/Bootstrap.java
+++ b/src/main/java/com.github.forax.pro.bootstrap/com/github/forax/pro/bootstrap/Bootstrap.java
@@ -94,14 +94,16 @@ public class Bootstrap {
 
       set("packager.moduleExplodedSourcePath", path("plugins/runner/target/main/exploded"));
       set("packager.moduleArtifactSourcePath", location("plugins/runner/target/main/artifact"));
-      
+
+      run("modulefixer", "compiler", "packager");
+
       FileHelper.walkAndFindCounterpart(
           location("plugins/runner/target/main/artifact"),
           location("target/main/artifact"),
           stream -> stream.filter(p -> p.toString().endsWith(".jar")),
           Files::copy);
       
-      run("modulefixer", "compiler", "packager");
+      run("packager");
     });
     
     


### PR DESCRIPTION
With this fix/workaround - running before and after the copy task - pro builds locally with "build.bat".

If "v0.9.165.1/pro-9-b165.1-linux.tar.gz" was still available at https://github.com/forax/pro/releases ... Travis would build, too.