### PR TITLE
Introduce tester.overrideArguments option

### DIFF
--- a/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/TesterConf.java
+++ b/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/TesterConf.java
@@ -2,11 +2,15 @@ package com.github.forax.pro.plugin.tester;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import com.github.forax.pro.api.TypeCheckedConfig;
 
 @TypeCheckedConfig
 public interface TesterConf {
+  Optional<List<String>> overrideArguments();
+  void overrideArguments(List<String> overrideArguments);
+
   List<Path> moduleExplodedTestPath();
   void moduleExplodedTestPath(List<Path> moduleExplodedTestPath);
 }

--- a/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/TesterPlugin.java
+++ b/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/TesterPlugin.java
@@ -60,7 +60,8 @@ public class TesterPlugin implements Plugin {
   }
   
   enum ConsoleLauncherOption {
-    SCAN_CLASSPATH(config -> Optional.of(line -> line.add("--scan-classpath"))),
+    // DISABLE_ANSI_COLORS(config -> Optional.of(line -> line.add("--disable-ansi-colors"))),
+    SCAN_CLASSPATH(actionLoop("--scan-classpath", TesterPlugin::directories)),
     CLASSPATH(actionLoop("--classpath", TesterPlugin::directories))
     ;
     
@@ -76,9 +77,17 @@ public class TesterPlugin implements Plugin {
     Log log = Log.create(name(), config.getOrThrow("pro", ProConf.class).loglevel());
     TesterConf tester = config.getOrThrow(name(), TesterConf.class);
     log.debug(tester, _tester -> "config " + _tester);
-    
-    String[] arguments = OptionAction.gatherAll(ConsoleLauncherOption.class, option -> option.action).apply(tester, new CmdLine()).toArguments();
-    log.verbose(null, __ -> OptionAction.toPrettyString(ConsoleLauncherOption.class, option -> option.action).apply(tester, "tester"));
+
+    String[] arguments;
+    if (tester.overrideArguments().isPresent()) {
+      List<String> overrideArguments = tester.overrideArguments().get();
+      arguments = overrideArguments.toArray(new String[0]);
+      log.verbose(arguments, __ -> "tester.overrideArguments=" + overrideArguments);
+    } else {
+      arguments = OptionAction.gatherAll(ConsoleLauncherOption.class, option -> option.action).apply(tester, new CmdLine()).toArguments();
+      log.verbose(null, __ -> OptionAction.toPrettyString(ConsoleLauncherOption.class, option -> option.action).apply(tester, "tester"));
+    }
+
 
     Thread currentThread = Thread.currentThread();
     ClassLoader oldContext = currentThread.getContextClassLoader();

--- a/src/test/java/com.github.forax.pro.api/com/github/forax/pro/api/helper/CmdLineTests.java
+++ b/src/test/java/com.github.forax.pro.api/com/github/forax/pro/api/helper/CmdLineTests.java
@@ -1,0 +1,31 @@
+package com.github.forax.pro.api.helper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class CmdLineTests {
+
+  @Test
+  void toStringWithoutArguments() {
+    CmdLine cmdLine = new CmdLine();
+    assertEquals("", cmdLine.toString());
+  }
+
+  @Test
+  void toStringWithSingleArgument() {
+    CmdLine cmdLine = new CmdLine();
+    cmdLine.add("one");
+    assertEquals("one", cmdLine.toString());
+  }
+
+  @Test
+  void toStringWithMultipleArguments() {
+    CmdLine cmdLine = new CmdLine();
+    cmdLine.add("one");
+    cmdLine.add("two");
+    cmdLine.add("three");
+    assertEquals("one two three", cmdLine.toString());
+  }
+
+}

--- a/src/test/java/com.github.forax.pro.api/com/github/forax/pro/api/impl/ConfigsTests.java
+++ b/src/test/java/com.github.forax.pro.api/com/github/forax/pro/api/impl/ConfigsTests.java
@@ -1,0 +1,14 @@
+package com.github.forax.pro.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+@Disabled("ConfigsTests (in unnamed module) cannot access class Configs (in module com.github.forax.pro.api)")
+class ConfigsTests {
+  @Test
+  void newRootIsNotNull() {
+    assertNotNull(Configs.newRoot());
+  }
+}

--- a/src/test/java/com.github.forax.pro.api/module-info.java
+++ b/src/test/java/com.github.forax.pro.api/module-info.java
@@ -1,0 +1,5 @@
+open module com.github.forax.pro.api {
+  requires junit.jupiter.api;
+  requires junit.platform.commons;
+  requires opentest4j;
+}

--- a/src/test/java/integration.pro/integration/pro/ProTests.java
+++ b/src/test/java/integration.pro/integration/pro/ProTests.java
@@ -1,0 +1,14 @@
+package integration.pro;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.forax.pro.Pro;
+import org.junit.jupiter.api.Test;
+
+class ProTests {
+
+  @Test
+  void list() {
+    assertEquals(0, Pro.list().size());
+  }
+}

--- a/src/test/java/integration.pro/module-info.java
+++ b/src/test/java/integration.pro/module-info.java
@@ -1,0 +1,7 @@
+module integration.pro {
+  requires junit.jupiter.api;
+  requires junit.platform.commons;
+  requires opentest4j;
+
+  requires com.github.forax.pro;
+}

--- a/test.pro
+++ b/test.pro
@@ -4,6 +4,14 @@ set("pro.loglevel", "verbose");
 
 // set("tester.overrideArguments", list("--help"))
 
+// run "pro" tests
+run("tester")
+
+// run "plugins" tests
+set("tester.moduleExplodedTestPath", list(path(
+  // "plugins/runner/target/test/exploded",
+  "plugins/tester/target/test/exploded"
+)))
 run("tester")
 
 /exit

--- a/test.pro
+++ b/test.pro
@@ -1,6 +1,8 @@
 import static com.github.forax.pro.Pro.*
 
-// set("tester.rawArguments", list("--help"))
+set("pro.loglevel", "verbose");
+
+// set("tester.overrideArguments", list("--help"))
 
 run("tester")
 


### PR DESCRIPTION
The list of strings passed via `tester.overrideArguments` replace all other configuration arguments normally gathered by the plugin. See comments in https://github.com/forax/pro/commit/aed2faed92b0d53753f80017d35ae9a98864dd95

This commit also fixes the ConsoleLauncher arguments to exclude the "." path from classpath scanning. The JShell sets "java.class.path" to "." which should not be scanned for test classes.