### PR TITLE
Plugin tester: module-path mode

### DIFF
--- a/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/ConventionFacade.java
+++ b/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/ConventionFacade.java
@@ -7,5 +7,6 @@ import com.github.forax.pro.api.TypeCheckedConfig;
 
 @TypeCheckedConfig
 public interface ConventionFacade {
-    List<Path> javaModuleExplodedTestPath();
+  Path javaHome();
+  List<Path> javaModuleExplodedTestPath();
 }

--- a/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/TesterConf.java
+++ b/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/TesterConf.java
@@ -8,8 +8,8 @@ import com.github.forax.pro.api.TypeCheckedConfig;
 
 @TypeCheckedConfig
 public interface TesterConf {
-  Optional<List<String>> overrideArguments();
-  void overrideArguments(List<String> overrideArguments);
+  Path javaHome();
+  void javaHome(Path path);
 
   List<Path> moduleExplodedTestPath();
   void moduleExplodedTestPath(List<Path> moduleExplodedTestPath);

--- a/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/TesterPlugin.java
+++ b/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/TesterPlugin.java
@@ -1,33 +1,27 @@
 package com.github.forax.pro.plugin.tester;
 
 import static com.github.forax.pro.api.MutableConfig.derive;
-import static com.github.forax.pro.api.helper.OptionAction.actionLoop;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
+import java.lang.module.Configuration;
 import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReference;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.concurrent.*;
 import java.util.stream.Collectors;
-
-import org.junit.platform.console.ConsoleLauncher;
-import org.junit.platform.engine.TestEngine;
 
 import com.github.forax.pro.api.Config;
 import com.github.forax.pro.api.MutableConfig;
 import com.github.forax.pro.api.Plugin;
 import com.github.forax.pro.api.WatcherRegistry;
-import com.github.forax.pro.api.helper.CmdLine;
-import com.github.forax.pro.api.helper.OptionAction;
 import com.github.forax.pro.api.helper.ProConf;
 import com.github.forax.pro.helper.Log;
 
 public class TesterPlugin implements Plugin {
+
+  private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
   @Override
   public String name() {
     return "tester";
@@ -37,89 +31,81 @@ public class TesterPlugin implements Plugin {
   public void init(MutableConfig config) {
     config.getOrUpdate(name(), TesterConf.class);
   }
-  
+
   @Override
   public void configure(MutableConfig config) {
     TesterConf tester = config.getOrUpdate(name(), TesterConf.class);
     ConventionFacade convention = config.getOrThrow("convention", ConventionFacade.class);
-    
+
     // inputs
+    derive(tester, TesterConf::javaHome, convention, ConventionFacade::javaHome);
     derive(tester, TesterConf::moduleExplodedTestPath, convention, ConventionFacade::javaModuleExplodedTestPath);
   }
-  
+
   @Override
   public void watch(Config config, WatcherRegistry registry) {
     TesterConf testerConf = config.getOrThrow(name(), TesterConf.class);
     testerConf.moduleExplodedTestPath().forEach(registry::watch);
   }
 
-  static List<Path> directories(TesterConf tester) {
-    return ModuleFinder.of(tester.moduleExplodedTestPath().toArray(new Path[0]))
-      .findAll()
-      .stream()
-      .flatMap(ref -> ref.location().stream())
-      .map(Paths::get)
-      .collect(Collectors.toList());
+  private static List<Path> directories(List<Path> paths) {
+    return ModuleFinder.of(paths.toArray(new Path[0]))
+        .findAll()
+        .stream()
+        .flatMap(ref -> ref.location().stream())
+        .map(Paths::get)
+        .collect(Collectors.toList());
   }
-  
-  enum ConsoleLauncherOption {
-    // DISABLE_ANSI_COLORS(config -> Optional.of(line -> line.add("--disable-ansi-colors"))),
-    SCAN_CLASSPATH(actionLoop("--scan-classpath", TesterPlugin::directories)),
-    CLASSPATH(actionLoop("--classpath", TesterPlugin::directories))
-    ;
-    
-    final OptionAction<TesterConf> action;
-    
-    private ConsoleLauncherOption(OptionAction<TesterConf> action) {
-      this.action = action;
-    }
-  }
-  
+
   @Override
-  public int execute(Config config) throws IOException {
+  public int execute(Config config) {
     Log log = Log.create(name(), config.getOrThrow("pro", ProConf.class).loglevel());
     TesterConf tester = config.getOrThrow(name(), TesterConf.class);
     log.debug(tester, _tester -> "config " + _tester);
 
-    String[] arguments = tester.overrideArguments()
-      .map(overrideArguments -> {
-        log.verbose(overrideArguments, _arguments -> String.join("\n", _arguments));
-        return overrideArguments.toArray(new String[0]);
-      })
-      .orElseGet(() -> {
-        log.verbose(null, __ -> OptionAction.toPrettyString(ConsoleLauncherOption.class, option -> option.action).apply(tester, "tester"));
-        return OptionAction.gatherAll(ConsoleLauncherOption.class, option -> option.action).apply(tester, new CmdLine()).toArguments();
-      });
-
     Thread currentThread = Thread.currentThread();
     ClassLoader oldContext = currentThread.getContextClassLoader();
     try {
-      currentThread.setContextClassLoader(TestEngine.class.getClassLoader());
-      return executeConsoleLauncher(arguments);
+      int exitCodeSum = 0;
+      for (Path path : directories(tester.moduleExplodedTestPath())) {
+        exitCodeSum += execute(tester, path.toAbsolutePath().normalize());
+      }
+      return exitCodeSum;
     } finally {
       currentThread.setContextClassLoader(oldContext); // restore the context
     }
   }
 
-  private static void dump(ByteArrayOutputStream data, Consumer<String> consumer) throws UnsupportedEncodingException {
-    Optional.of(data.toString("UTF-8"))
-      .filter(text -> !text.trim().isEmpty())
-      .ifPresent(consumer);
+  private int execute(TesterConf tester, Path testPath) {
+    ModuleReference moduleReference = ModuleFinder.of(testPath).findAll().iterator().next();
+    String moduleName = moduleReference.descriptor().name();
+    ClassLoader testClassLoader = createTestClassLoader(tester, testPath, moduleName);
+    Thread.currentThread().setContextClassLoader(testClassLoader);
+    try {
+      Class<?> runnerClass = testClassLoader.loadClass(TesterRunner.class.getName());
+      @SuppressWarnings("unchecked")
+      Callable<Integer> runner = (Callable<Integer>) runnerClass.getConstructor(Path.class).newInstance(testPath);
+      Future<Integer> future = executor.submit(runner);
+      return future.get(1, TimeUnit.MINUTES);
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new AssertionError("Loading and invoking TestRunner failed", e);
+    }
   }
-  
-  private static int executeConsoleLauncher(String[] arguments) throws IOException {
-    ByteArrayOutputStream dataOut = new ByteArrayOutputStream();
-    ByteArrayOutputStream dataErr = new ByteArrayOutputStream();
-    
-    int exitCode = ConsoleLauncher.execute(
-        new PrintStream(dataOut, true, "UTF-8"),
-        new PrintStream(dataErr, true, "UTF-8"),
-        arguments
-        ).getExitCode();
-    
-    dump(dataOut, System.out::print);
-    dump(dataErr, System.err::print);
-    
-    return exitCode;
+
+  private ClassLoader createTestClassLoader(TesterConf tester, Path testPath, String moduleName) {
+    String pluginModuleName = getClass().getModule().getName(); // com.github.forax.pro.plugin.tester
+    Path pluginRoot = tester.javaHome().resolve("plugins").resolve(name());
+    Path mainDependenciesPath = Paths.get("deps").toAbsolutePath().normalize();
+    Path mainArtifactPath = Paths.get("target/main/artifact").toAbsolutePath().normalize();
+    List<Path> paths = List.of(testPath, pluginRoot, mainDependenciesPath, mainArtifactPath);
+    // System.out.println("Using ModuleFinder root path entries: " + paths);
+    ModuleFinder finder = ModuleFinder.of(paths.toArray(new Path[0]));
+    ModuleLayer boot = ModuleLayer.boot();
+    Configuration cf = boot.configuration().resolve(finder, ModuleFinder.of(), List.of(pluginModuleName, moduleName));
+    ClassLoader parentLoader = ClassLoader.getSystemClassLoader();
+    ModuleLayer layer = boot.defineModulesWithOneLoader(cf, parentLoader);
+    return layer.findLoader(pluginModuleName);
   }
+
 }

--- a/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/TesterRunner.java
+++ b/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/TesterRunner.java
@@ -1,0 +1,82 @@
+package com.github.forax.pro.plugin.tester;
+
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReader;
+import java.lang.module.ModuleReference;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+public class TesterRunner implements Callable<Integer> {
+
+    private final Path testPath;
+
+    public TesterRunner(Path testPath) {
+        this.testPath = testPath;
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        ModuleReference moduleReference = ModuleFinder.of(testPath).findAll().iterator().next();
+        System.out.println("Test run of module " + moduleReference.descriptor().name() + " starts...");
+        List<Class<?>> testClasses = findTestClasses(moduleReference);
+        Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+        Launcher launcher = LauncherFactory.create();
+        return launch(launcher, testClasses);
+    }
+
+    private int launch(Launcher launcher, List<Class<?>> testClasses) {
+        LauncherDiscoveryRequestBuilder builder = LauncherDiscoveryRequestBuilder.request();
+        for (Class<?> testClass : testClasses) {
+            builder.selectors(selectClass(testClass));
+        }
+        LauncherDiscoveryRequest launcherDiscoveryRequest = builder.build();
+        SummaryGeneratingListener summaryGeneratingListener = new SummaryGeneratingListener();
+        launcher.execute(launcherDiscoveryRequest, summaryGeneratingListener);
+        StringWriter stringWriter = new StringWriter();
+        summaryGeneratingListener.getSummary().printTo(new PrintWriter(stringWriter));
+        summaryGeneratingListener.getSummary().printFailuresTo(new PrintWriter(stringWriter));
+        System.out.println(stringWriter);
+        return (int) summaryGeneratingListener.getSummary().getTestsFailedCount();
+    }
+
+    private List<Class<?>> findTestClasses(ModuleReference moduleReference) {
+        List<String> entries;
+        try (ModuleReader moduleReader = moduleReference.open()) {
+            entries = moduleReader.list()
+                    .filter(name -> name.endsWith("Tests.class"))
+                    .collect(Collectors.toList());
+        }
+        catch (IOException exception) {
+            throw new AssertionError("module reader failure", exception);
+        }
+        List<Class<?>> testClasses = new ArrayList<>();
+        for (String entry : entries) {
+            String name = entry.substring(0, entry.length() - ".class".length());
+            name = name.replace('/','.');
+            try {
+                // Thread.currentThread().getContextClassLoader()
+                Class<?> testClass = getClass().getClassLoader().loadClass(name);
+                testClasses.add(testClass);
+            } catch (Exception exception) {
+                exception.printStackTrace();
+                throw new AssertionError("Loading failed for name: " + name + " (entry=" + entry + ")", exception);
+            }
+        }
+        return testClasses;
+    }
+
+}

--- a/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/module-info.java
+++ b/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/module-info.java
@@ -2,9 +2,29 @@ module com.github.forax.pro.plugin.tester {
   requires com.github.forax.pro.api;
   requires com.github.forax.pro.helper;
 
-  requires junit.platform.console.standalone;
+  // java.lang.IllegalAccessException:
+  //   class com.github.forax.pro.plugin.tester.TesterPlugin (in module com.github.forax.pro.plugin.tester)
+  // cannot access
+  //   class com.github.forax.pro.plugin.tester.TesterRunner (in module com.github.forax.pro.plugin.tester)
+  // because
+  //   module com.github.forax.pro.plugin.tester
+  // does not export
+  //   com.github.forax.pro.plugin.tester
+  // to
+  //   module com.github.forax.pro.plugin.tester
+  exports com.github.forax.pro.plugin.tester;
 
-  opens com.github.forax.pro.plugin.tester;
+  // Open Test Alliance for the JVM
+  requires opentest4j;
+
+  // JUnit Platform
+  requires junit.platform.commons;
+  requires junit.platform.engine;
+  requires junit.platform.launcher;
+
+  // JUnit Jupiter
+  requires junit.jupiter.api;
+  requires junit.jupiter.engine;
   
   provides com.github.forax.pro.api.Plugin
     with com.github.forax.pro.plugin.tester.TesterPlugin;

--- a/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/module-info.java
+++ b/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/module-info.java
@@ -4,16 +4,11 @@ module com.github.forax.pro.plugin.tester {
 
   opens com.github.forax.pro.plugin.tester;
 
-  // Open Test Alliance for the JVM
-  requires opentest4j;
-
   // JUnit Platform
-  requires junit.platform.commons;
   requires junit.platform.engine;
   requires junit.platform.launcher;
 
   // JUnit Jupiter
-  requires junit.jupiter.api;
   requires junit.jupiter.engine;
   
   provides com.github.forax.pro.api.Plugin

--- a/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/module-info.java
+++ b/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/module-info.java
@@ -2,17 +2,7 @@ module com.github.forax.pro.plugin.tester {
   requires com.github.forax.pro.api;
   requires com.github.forax.pro.helper;
 
-  // java.lang.IllegalAccessException:
-  //   class com.github.forax.pro.plugin.tester.TesterPlugin (in module com.github.forax.pro.plugin.tester)
-  // cannot access
-  //   class com.github.forax.pro.plugin.tester.TesterRunner (in module com.github.forax.pro.plugin.tester)
-  // because
-  //   module com.github.forax.pro.plugin.tester
-  // does not export
-  //   com.github.forax.pro.plugin.tester
-  // to
-  //   module com.github.forax.pro.plugin.tester
-  exports com.github.forax.pro.plugin.tester;
+  opens com.github.forax.pro.plugin.tester;
 
   // Open Test Alliance for the JVM
   requires opentest4j;

--- a/plugins/tester/src/test/java/com.github.forax.pro.plugin.tester/module-info.java
+++ b/plugins/tester/src/test/java/com.github.forax.pro.plugin.tester/module-info.java
@@ -1,3 +1,2 @@
 module com.github.forax.pro.plugin.tester {
-  requires junit.platform.console.standalone;
 }

--- a/plugins/tester/src/test/java/com.github.forax.pro.plugin.tester/module-info.java
+++ b/plugins/tester/src/test/java/com.github.forax.pro.plugin.tester/module-info.java
@@ -1,2 +1,3 @@
 module com.github.forax.pro.plugin.tester {
+  requires junit.jupiter.api;
 }

--- a/src/main/java/com.github.forax.pro.bootstrap/com/github/forax/pro/bootstrap/Bootstrap.java
+++ b/src/main/java/com.github.forax.pro.bootstrap/com/github/forax/pro/bootstrap/Bootstrap.java
@@ -86,7 +86,14 @@ public class Bootstrap {
         uri("https://oss.sonatype.org/content/repositories/snapshots")
       ));
       set("resolver.dependencies", list(
-        "junit.platform.console.standalone=org.junit.platform:junit-platform-console-standalone:1.0.0-SNAPSHOT"
+          // "API"
+          "opentest4j=org.opentest4j:opentest4j:1.0.0-M2",
+          "junit.platform.commons=org.junit.platform:junit-platform-commons:1.0.0-M4",
+          "junit.jupiter.api=org.junit.jupiter:junit-jupiter-api:5.0.0-M4",
+          // "Launcher + Engine"
+          "junit.platform.engine=org.junit.platform:junit-platform-engine:1.0.0-M4",
+          "junit.platform.launcher=org.junit.platform:junit-platform-launcher:1.0.0-M4",
+          "junit.jupiter.engine=org.junit.jupiter:junit-jupiter-engine:5.0.0-M4"
       ));
     });
 

--- a/src/main/java/com.github.forax.pro.helper/com/github/forax/pro/helper/FileHelper.java
+++ b/src/main/java/com.github.forax.pro.helper/com/github/forax/pro/helper/FileHelper.java
@@ -6,6 +6,7 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -24,7 +25,12 @@ public class FileHelper {
   public static List<Path> pathFromFilesThatExist(List<Path> paths) {
     return List.of(paths.stream().filter(Files::exists).toArray(Path[]::new));
   }
-  
+
+  public static Path relativize(Path path) {
+    Path workingDirectory = Paths.get(".").toAbsolutePath().normalize();
+    return workingDirectory.relativize(path.toAbsolutePath().normalize());
+  }
+
   /**
    * Delete recursively all files inside a directory.
    * @param directory a directory

--- a/src/test/java/com.github.forax.pro.api/com/github/forax/pro/api/helper/CmdLineTests.java
+++ b/src/test/java/com.github.forax.pro.api/com/github/forax/pro/api/helper/CmdLineTests.java
@@ -7,20 +7,20 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("static-method")
 class CmdLineTests {
   @Test
-  public void toStringWithoutArguments() {
+  void toStringWithoutArguments() {
     CmdLine cmdLine = new CmdLine();
     assertEquals("", cmdLine.toString());
   }
 
   @Test
-  public void toStringWithSingleArgument() {
+  void toStringWithSingleArgument() {
     CmdLine cmdLine = new CmdLine();
     cmdLine.add("one");
     assertEquals("one", cmdLine.toString());
   }
 
   @Test
-  public void toStringWithMultipleArguments() {
+  void toStringWithMultipleArguments() {
     CmdLine cmdLine = new CmdLine();
     cmdLine.add("one");
     cmdLine.add("two");

--- a/src/test/java/com.github.forax.pro.api/com/github/forax/pro/api/impl/ConfigsTests.java
+++ b/src/test/java/com.github.forax.pro.api/com/github/forax/pro/api/impl/ConfigsTests.java
@@ -2,14 +2,12 @@ package com.github.forax.pro.api.impl;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("static-method")
-@Disabled("ConfigsTests (in unnamed module) cannot access class Configs (in module com.github.forax.pro.api)")
 class ConfigsTests {
   @Test
-  public void newRootIsNotNull() {
+  void newRootIsNotNull() {
     assertNotNull(new DefaultConfig().asConfig());
   }
 }

--- a/src/test/java/com.github.forax.pro.api/module-info.java
+++ b/src/test/java/com.github.forax.pro.api/module-info.java
@@ -1,6 +1,3 @@
 open module com.github.forax.pro.api {
   requires junit.jupiter.api;
-  requires junit.platform.commons;
-  
-  requires opentest4j;
 }

--- a/src/test/java/com.github.forax.pro.helper/com/github/forax/pro/helper/FileHelperTests.java
+++ b/src/test/java/com.github.forax.pro.helper/com/github/forax/pro/helper/FileHelperTests.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("static-method")
 class FileHelperTests {
   @Test
-  public void pathFilenameEndsWith() {
+  void pathFilenameEndsWith() {
     Predicate<Path> predicate = FileHelper.pathFilenameEndsWith("foo");
     Assertions.assertTrue(predicate.test(Paths.get("bar.foo")));
   }

--- a/src/test/java/com.github.forax.pro.helper/com/github/forax/pro/helper/PlatformTests.java
+++ b/src/test/java/com.github.forax.pro.helper/com/github/forax/pro/helper/PlatformTests.java
@@ -13,12 +13,12 @@ import org.junit.jupiter.api.TestFactory;
 @SuppressWarnings("static-method")
 class PlatformTests {
   @Test
-  public void currentPlatformIsNotNull() {
+  void currentPlatformIsNotNull() {
     Assertions.assertNotNull(Platform.current());
   }
 
   @TestFactory
-  public Stream<DynamicTest> javaExecutableNamesAreNotBlank() {
+  Stream<DynamicTest> javaExecutableNamesAreNotBlank() {
     return DynamicTest.stream(
         Arrays.asList(Platform.values()).iterator(),
         Object::toString,
@@ -30,7 +30,7 @@ class PlatformTests {
   }
 
   @Test
-  public void javaExecutableNamePointsToExecutableFile() {
+  void javaExecutableNamePointsToExecutableFile() {
     String name = Platform.current().javaExecutableName();
     Path path = Paths.get(System.getProperty("java.home")).resolve("bin").resolve(name);
     Assertions.assertTrue(Files.isExecutable(path), "executable? " + path);

--- a/src/test/java/com.github.forax.pro.helper/com/github/forax/pro/helper/util/StableListTests.java
+++ b/src/test/java/com.github.forax.pro.helper/com/github/forax/pro/helper/util/StableListTests.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 class StableListTests {
 
   @Test
-  public void append() {
+  void append() {
     StableList<String> list1 = new StableList<>();
     StableList<String> list2 = list1.append("foo").append("bar");
     StableList<String> list3 = list2.append("baz");

--- a/src/test/java/com.github.forax.pro.helper/module-info.java
+++ b/src/test/java/com.github.forax.pro.helper/module-info.java
@@ -1,5 +1,3 @@
 open module com.github.forax.pro.helper {
   requires junit.jupiter.api;
-  requires junit.platform.commons;
-  requires opentest4j;
 }

--- a/src/test/java/integration.pro/integration/pro/AetherTests.java
+++ b/src/test/java/integration.pro/integration/pro/AetherTests.java
@@ -1,0 +1,17 @@
+package integration.pro;
+
+import com.github.forax.pro.aether.Aether;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SuppressWarnings("static-method")
+class AetherTests {
+  @Test
+  void create() throws Exception {
+    assertNotNull(Aether.create(Files.createTempDirectory("AetherTests-create-"), List.of()));
+  }
+}

--- a/src/test/java/integration.pro/integration/pro/ProTests.java
+++ b/src/test/java/integration.pro/integration/pro/ProTests.java
@@ -3,12 +3,14 @@ package integration.pro;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.forax.pro.Pro;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("static-method")
-public class ProTests {
+class ProTests {
   @Test
-  public void list() {
+  @Disabled("java.util.ServiceConfigurationError: com.github.forax.pro.api.Plugin: com.github.forax.pro.plugin.modulefixer.ModuleFixerPlugin not a subtype")
+  void list() {
     assertEquals(0, Pro.list().size());
   }
 }

--- a/src/test/java/integration.pro/module-info.java
+++ b/src/test/java/integration.pro/module-info.java
@@ -1,8 +1,5 @@
-// remove "open" from module header and use: exports integration.pro to junit.platform.commons;
 open module integration.pro {
   requires junit.jupiter.api;
-  requires junit.platform.commons;
-  requires opentest4j;
 
   requires com.github.forax.pro;
   requires com.github.forax.pro.aether;

--- a/src/test/java/integration.pro/module-info.java
+++ b/src/test/java/integration.pro/module-info.java
@@ -1,7 +1,9 @@
+// remove "open" from module header and use: exports integration.pro to junit.platform.commons;
 open module integration.pro {
   requires junit.jupiter.api;
   requires junit.platform.commons;
   requires opentest4j;
 
   requires com.github.forax.pro;
+  requires com.github.forax.pro.aether;
 }

--- a/test.pro
+++ b/test.pro
@@ -1,6 +1,13 @@
 import static com.github.forax.pro.Pro.*
 
-set("pro.loglevel", "verbose");
+// run "pro" tests
+run("tester")
+
+// run "plugins" tests
+set("tester.moduleExplodedTestPath", list(path(
+  // "plugins/runner/target/test/exploded",
+  "plugins/tester/target/test/exploded"
+)))
 run("tester")
 
 /exit

--- a/test.pro
+++ b/test.pro
@@ -1,17 +1,6 @@
 import static com.github.forax.pro.Pro.*
 
 set("pro.loglevel", "verbose");
-
-// set("tester.overrideArguments", list("--help"))
-
-// run "pro" tests
-run("tester")
-
-// run "plugins" tests
-set("tester.moduleExplodedTestPath", list(path(
-  // "plugins/runner/target/test/exploded",
-  "plugins/tester/target/test/exploded"
-)))
 run("tester")
 
 /exit


### PR DESCRIPTION
This PR implements a module-path mode for the **tester** plugin.

Addresses #30 

See https://travis-ci.org/forax/pro/builds/229615764#L304 -- and note the lack of the trees. They are part of the "JUnit Console" module, which is no longer required by the **tester** plugin.

## TODO

- [ ] Code cleanup
- [ ] Provide basic options like test class filter, time out settings, parallell execution...