### PR TITLE
Add external plugin: "formatter"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ script:
 - chmod u+x ./build.sh
 - ./build.sh
 - ./target/pro/bin/pro build test.pro
+- ./target/pro/bin/pro build format.pro

--- a/format.pro
+++ b/format.pro
@@ -1,0 +1,8 @@
+import static com.github.forax.pro.Pro.*
+
+set("pro.loglevel", "verbose")
+
+// set("formatter.rawArguments", list("--replace"))
+run("formatter")
+
+/exit

--- a/plugins/formatter/.gitignore
+++ b/plugins/formatter/.gitignore
@@ -1,0 +1,3 @@
+/deps/
+/libs/
+/target/

--- a/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/com/github/forax/pro/plugin/formatter/ConventionFacade.java
+++ b/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/com/github/forax/pro/plugin/formatter/ConventionFacade.java
@@ -1,0 +1,13 @@
+package com.github.forax.pro.plugin.formatter;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import com.github.forax.pro.api.TypeCheckedConfig;
+
+@TypeCheckedConfig
+public interface ConventionFacade {
+  Path javaHome();
+  List<Path> javaModuleSourcePath();
+  List<Path> javaModuleTestPath();
+}

--- a/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/com/github/forax/pro/plugin/formatter/FormatterConf.java
+++ b/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/com/github/forax/pro/plugin/formatter/FormatterConf.java
@@ -1,0 +1,27 @@
+package com.github.forax.pro.plugin.formatter;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import com.github.forax.pro.api.TypeCheckedConfig;
+import java.util.Optional;
+
+@TypeCheckedConfig
+public interface FormatterConf {
+
+  // Derived from convention
+
+  List<Path> moduleSourcePath();
+  void moduleSourcePath(List<Path> modulePath);
+
+  List<Path> moduleTestPath();
+  void moduleTestPath(List<Path> modulePath);
+
+  // Formatter options
+
+  Optional<List<String>> rawArguments();
+  void rawArguments(List<String> rawArguments);
+
+  Optional<List<Path>> files();
+  void files(List<Path> files);
+}

--- a/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/com/github/forax/pro/plugin/formatter/FormatterPlugin.java
+++ b/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/com/github/forax/pro/plugin/formatter/FormatterPlugin.java
@@ -1,0 +1,139 @@
+package com.github.forax.pro.plugin.formatter;
+
+import static com.github.forax.pro.api.MutableConfig.derive;
+import static com.github.forax.pro.helper.FileHelper.pathFilenameEndsWith;
+import static com.github.forax.pro.helper.FileHelper.pathFilenameEquals;
+import static com.github.forax.pro.helper.FileHelper.walkIfNecessary;
+
+import com.github.forax.pro.api.Config;
+import com.github.forax.pro.api.MutableConfig;
+import com.github.forax.pro.api.Plugin;
+import com.github.forax.pro.api.WatcherRegistry;
+import com.github.forax.pro.api.helper.CmdLine;
+import com.github.forax.pro.api.helper.ProConf;
+import com.github.forax.pro.helper.Log;
+import com.github.forax.pro.helper.Platform;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.zip.CRC32;
+
+public class FormatterPlugin implements Plugin {
+  @Override
+  public String name() {
+    return "formatter";
+  }
+
+  @Override
+  public void init(MutableConfig config) {
+    config.getOrUpdate(name(), FormatterConf.class);
+  }
+  
+  @Override
+  public void configure(MutableConfig config) {
+    FormatterConf formatter = config.getOrUpdate(name(), FormatterConf.class);
+    ConventionFacade convention = config.getOrThrow("convention", ConventionFacade.class);
+
+    derive(formatter, FormatterConf::moduleSourcePath, convention, ConventionFacade::javaModuleSourcePath);
+    derive(formatter, FormatterConf::moduleTestPath, convention, ConventionFacade::javaModuleTestPath);
+  }
+
+  private List<Path> listAllJavaFiles(FormatterConf formatter) {
+    Predicate<Path> filter = pathFilenameEndsWith(".java");
+    // TODO include "module-info.java" files, blocked by https://github.com/google/google-java-format/issues/75
+    filter = filter.and(pathFilenameEquals("module-info.java").negate());
+
+    List<Path> pathList = new ArrayList<>();
+    pathList.addAll(formatter.moduleSourcePath());
+    pathList.addAll(formatter.moduleTestPath());
+    return walkIfNecessary(pathList, filter);
+  }
+  
+  @Override
+  public void watch(Config config, WatcherRegistry registry) {
+    FormatterConf formatter = config.getOrThrow(name(), FormatterConf.class);
+    formatter.moduleSourcePath().forEach(registry::watch);
+    formatter.moduleTestPath().forEach(registry::watch);
+  }
+
+  @Override
+  public int execute(Config config) throws IOException {
+    Log log = Log.create(name(), config.getOrThrow("pro", ProConf.class).loglevel());
+    ConventionFacade convention = config.getOrThrow("convention", ConventionFacade.class);
+    FormatterConf formatter = config.getOrThrow(name(), FormatterConf.class);
+    log.debug(formatter, _formatter -> "config " + _formatter);
+
+    CmdLine cmdLine = new CmdLine();
+    cmdLine.add(convention.javaHome().resolve("bin").resolve(Platform.current().javaExecutableName()));
+    cmdLine.add("--module-path");
+    cmdLine.add(convention.javaHome().resolve("plugins").resolve(name()).resolve("libs"));
+    cmdLine.add("--module");
+    cmdLine.add("google.java.format");
+    // no (raw) arguments will trigger default "format files to stdout" mode
+    formatter.rawArguments().ifPresent(args -> args.forEach(cmdLine::add));
+    log.verbose(cmdLine, CmdLine::toString);
+    // files
+    List<Path> files = formatter.files().orElseGet(() -> listAllJavaFiles(formatter));
+    long initialChecksum = crc(files);
+    log.verbose(files, fs -> fs.size() + " files (0x" + Long.toHexString(initialChecksum) + ")...");
+    log.debug(files, fs -> "files:\n" + fs.stream().map(Path::toString).collect(Collectors.joining(" ")));
+    files.forEach(cmdLine::add);
+
+    Process process = new ProcessBuilder(cmdLine.toArguments()).redirectErrorStream(true).start();
+    ByteArrayOutputStream captured = new ByteArrayOutputStream();
+    process.getInputStream().transferTo(new PrintStream(captured, true, "UTF-8"));
+    try {
+      int errorCode = process.waitFor();
+      long capturedChecksum = crc(captured.toString("UTF-8"));
+      if (errorCode != 0) {
+        dump(captured, System.out::print);
+      }
+      if (capturedChecksum == 0L) {
+        return errorCode;
+      }
+      if (initialChecksum - capturedChecksum == 0L) {
+        return errorCode;
+      }
+    } catch (InterruptedException e) {
+      // fall-through
+    }
+    return 1; // FIXME
+  }
+
+  private static void dump(ByteArrayOutputStream data, Consumer<String> consumer) throws UnsupportedEncodingException {
+    Optional.of(data.toString("UTF-8"))
+            .filter(text -> !text.trim().isEmpty())
+            .ifPresent(consumer);
+  }
+
+  private static long crc(String string) {
+    CRC32 crc32 = new CRC32();
+    crc32.update(string.getBytes(StandardCharsets.UTF_8));
+    return crc32.getValue();
+  }
+
+  private static long crc(List<Path> files) {
+    return crc(new CRC32(), files);
+  }
+
+  private static long crc(CRC32 crc32, List<Path> files) {
+    try {
+      for (Path path : files) {
+        crc32.update(Files.readAllBytes(path));
+      }
+    } catch (Exception e) {
+      throw new AssertionError(e);
+    }
+    return crc32.getValue();
+  }
+}

--- a/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/module-info.java
+++ b/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/module-info.java
@@ -1,0 +1,7 @@
+module com.github.forax.pro.plugin.formatter {
+  requires com.github.forax.pro.api;
+  requires com.github.forax.pro.helper;
+
+  provides com.github.forax.pro.api.Plugin
+    with com.github.forax.pro.plugin.formatter.FormatterPlugin;
+}


### PR DESCRIPTION
### Overview

Based on [google-java-format](https://github.com/google/google-java-format) -- a program that reformats Java source code to comply with [Google Java Style](https://google.github.io/styleguide/javaguide.html).

The current implementation uses the `--module-path` option to launch the program. I didn't managed to make modules via _module-fixer_ out of neither the "-all-deps" distro nor the 3 single jars:  `google-java-format-1.3.jar`, `guava-19.0.jar` and `javac-9-dev-r3297-1-shaded.jar`

The "-all-deps" jar is downloaded on-the-fly  via `Boostrap.download(...)` -- a candidate for `Pro` itself?

The "-all-deps" jar is stored in a subfolder called `plugins/formatter/libs/`. All jars found in that folder are not resolved, nor module-fixed. They are copied over to the `target/pro` image as-is.

### TODO

- [ ] Review and discuss the plugin implementation -- maybe, it's even better to not include it.
- [ ] add more google-java-format command line options, see details [here](https://github.com/google/google-java-format/blob/master/core/src/main/java/com/google/googlejavaformat/java/UsageException.java#L30)
- [ ] make `javaFiles()` configurable
- [x] pro-internal `java` provides a "fake-guava" module which collides with the one bundled in google-java-format-<VERSION>-all-deps.jar -- is falling back to "external java" a real option? Solved via https://github.com/forax/pro/pull/34/commits/156ec79b350aea55a3adf0de0151c28ea1a48208
