### PR TITLE
Tester cleanup

### DIFF
--- a/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/TesterRunner.java
+++ b/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/TesterRunner.java
@@ -1,15 +1,16 @@
 package com.github.forax.pro.plugin.tester;
 
+import com.github.forax.pro.helper.ModuleHelper;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
 
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.lang.module.ModuleFinder;
 import java.lang.module.ModuleReader;
 import java.lang.module.ModuleReference;
 import java.nio.file.Path;
@@ -22,20 +23,27 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 
 public class TesterRunner implements Callable<Integer> {
 
+    private final ClassLoader classLoader;
     private final Path testPath;
 
     public TesterRunner(Path testPath) {
+        this.classLoader = getClass().getClassLoader();
         this.testPath = testPath;
     }
 
     @Override
-    public Integer call() throws Exception {
-        ModuleReference moduleReference = ModuleFinder.of(testPath).findAll().iterator().next();
-        System.out.println("Test run of module " + moduleReference.descriptor().name() + " starts...");
-        List<Class<?>> testClasses = findTestClasses(moduleReference);
-        Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
-        Launcher launcher = LauncherFactory.create();
-        return launch(launcher, testClasses);
+    public Integer call() {
+        ClassLoader oldContext = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(classLoader);
+        try {
+            ModuleReference moduleReference = ModuleHelper.getOnlyModule(testPath);
+            System.out.println("[tester] Test run of module " + moduleReference.descriptor().name() + " starts...");
+            List<Class<?>> testClasses = findTestClasses(moduleReference);
+            Launcher launcher = LauncherFactory.create();
+            return launch(launcher, testClasses);
+        } finally {
+            Thread.currentThread().setContextClassLoader(oldContext);
+        }
     }
 
     private int launch(Launcher launcher, List<Class<?>> testClasses) {
@@ -46,18 +54,24 @@ public class TesterRunner implements Callable<Integer> {
         LauncherDiscoveryRequest launcherDiscoveryRequest = builder.build();
         SummaryGeneratingListener summaryGeneratingListener = new SummaryGeneratingListener();
         launcher.execute(launcherDiscoveryRequest, summaryGeneratingListener);
-        StringWriter stringWriter = new StringWriter();
-        summaryGeneratingListener.getSummary().printTo(new PrintWriter(stringWriter));
-        summaryGeneratingListener.getSummary().printFailuresTo(new PrintWriter(stringWriter));
-        System.out.println(stringWriter);
-        return (int) summaryGeneratingListener.getSummary().getTestsFailedCount();
+        TestExecutionSummary summary = summaryGeneratingListener.getSummary();
+        int failures = (int) summary.getTestsFailedCount();
+        if (failures == 0) {
+            System.out.println("[tester] Test run successfully executed " + summary.getTestsSucceededCount() + " tests.");
+        } else {
+            StringWriter stringWriter = new StringWriter();
+            summary.printTo(new PrintWriter(stringWriter));
+            summary.printFailuresTo(new PrintWriter(stringWriter));
+            System.out.println(stringWriter);
+        }
+        return failures;
     }
 
     private List<Class<?>> findTestClasses(ModuleReference moduleReference) {
         List<String> entries;
         try (ModuleReader moduleReader = moduleReference.open()) {
             entries = moduleReader.list()
-                    .filter(name -> name.endsWith("Tests.class"))
+                    .filter(name -> name.endsWith("Tests.class")) // TODO Make test class filter configurable
                     .collect(Collectors.toList());
         }
         catch (IOException exception) {
@@ -68,7 +82,6 @@ public class TesterRunner implements Callable<Integer> {
             String name = entry.substring(0, entry.length() - ".class".length());
             name = name.replace('/','.');
             try {
-                // Thread.currentThread().getContextClassLoader()
                 Class<?> testClass = getClass().getClassLoader().loadClass(name);
                 testClasses.add(testClass);
             } catch (Exception exception) {

--- a/src/main/java/com.github.forax.pro.helper/com/github/forax/pro/helper/ModuleHelper.java
+++ b/src/main/java/com.github.forax.pro.helper/com/github/forax/pro/helper/ModuleHelper.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -64,6 +65,24 @@ public class ModuleHelper {
   public static Stream<ModuleReference> findAllModulesWhichProvideAService(List<String> serviceNames, ModuleFinder finder) {
     return finder.findAll().stream()
         .filter(ref -> containsAtLeastAService(ref, serviceNames));
+  }
+
+  /**
+   * Returns the single module contained in {@code path} as a {@link ModuleReference}.
+   */
+  public static ModuleReference getOnlyModule(Path path) {
+    Iterator<ModuleReference> iterator = ModuleFinder.of(path).findAll().iterator();
+    ModuleReference first = iterator.next();
+    if (!iterator.hasNext()) {
+      return first;
+    }
+    StringBuilder sb = new StringBuilder();
+    sb.append("expected one module but was: <").append(first);
+    while (iterator.hasNext()) {
+      sb.append(", ").append(iterator.next());
+    }
+    sb.append('>');
+    throw new IllegalArgumentException(sb.toString());
   }
   
   private static Set<Requires.Modifier> requireModifiers(int modifiers) {


### PR DESCRIPTION
- TCCL not longer used, living inside own module layer.
- Introduce ModuleHelper.getOnlyModule(Path) helper.
- Cleanup createTestClassLoader method.