### PR TITLE
Add module dependency path to tester finder roots

### DIFF
--- a/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/ConventionFacade.java
+++ b/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/ConventionFacade.java
@@ -8,4 +8,5 @@ import com.github.forax.pro.api.TypeCheckedConfig;
 @TypeCheckedConfig
 public interface ConventionFacade {
   List<Path> javaModuleExplodedTestPath();
+  List<Path> javaModuleDependencyPath();
 }

--- a/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/TesterConf.java
+++ b/plugins/tester/src/main/java/com.github.forax.pro.plugin.tester/com/github/forax/pro/plugin/tester/TesterConf.java
@@ -14,6 +14,8 @@ public interface TesterConf {
   // convention
   List<Path> moduleExplodedTestPath();
   void moduleExplodedTestPath(List<Path> moduleExplodedTestPath);
+  List<Path> moduleDependencyPath();
+  void moduleDependencyPath(List<Path> moduleDependencyPath);
 
   // tester
   int timeout();


### PR DESCRIPTION
This commit enables user-defined test dependencies to be picked-up by the
tester plugin class loader. With this custom test engines can be loaded,
like JUnit Vintage (JUnit 4) or https://github.com/jlink/jqwik