### PR TITLE
Manually install jdk-9-ea+b168 and use it to build pro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,18 @@ dist: trusty
 language: java
 
 install:
-- wget --no-check-certificate https://github.com/forax/pro/releases/download/v0.9.167/pro-9-b167-linux.tar.gz
-- tar -xzf pro-9-b167-linux.tar.gz
-- export JAVA_HOME=./pro
-- ./pro/bin/pro version
+# Download pro binaries (with bundled jdk) from github.com
+#- wget --no-check-certificate https://github.com/forax/pro/releases/download/v0.9.167/pro-9-b167-linux.tar.gz
+#- tar -xzf pro-9-b167-linux.tar.gz
+#- export JAVA_HOME=./pro
+#- ./pro/bin/pro version
+
+# Download and "install" jdk-9 from java.net
+- wget http://download.java.net/java/jdk9/archive/168/binaries/jdk-9-ea+168_linux-x64_bin.tar.gz
+- tar -xzf jdk-9-ea+168_linux-x64_bin.tar.gz
+- export JAVA_HOME=$PWD/jdk-9
+- PATH=$JAVA_HOME/bin:$PATH
+- java -version
 
 script:
 - chmod u+x ./build.sh


### PR DESCRIPTION
With this PR Travis CI is using **jdk-9-ea+b168** instead of the out-dated **b162** from
- https://launchpad.net/~webupd8team/+archive/ubuntu/java?field.series_filter=trusty  

or the jdk linked into (pre-)released pro binaries.