### PR TITLE
Fix module source generator

### DIFF
--- a/src/main/java/com.github.forax.pro.helper/com/github/forax/pro/helper/ModuleHelper.java
+++ b/src/main/java/com.github.forax.pro.helper/com/github/forax/pro/helper/ModuleHelper.java
@@ -396,7 +396,7 @@ public class ModuleHelper {
     return new Generator()
           .$("%s",             desc -> desc.isOpen()? "open":"")
           .$("module %s {",    ModuleDescriptor::name)
-          .$("  requires %s;", ModuleDescriptor::requires, Requires::name)
+          .$("  requires %s;", ModuleDescriptor::requires, Requires::toString)
           .$("  exports %s;",  ModuleDescriptor::exports,  Exports::source,   "to %s", Exports::targets)
           .$("  opens %s;",    ModuleDescriptor::opens,    Opens::source,     "to %s", Opens::targets)
           .$("")

--- a/src/test/java/com.github.forax.pro.helper/com/github/forax/pro/helper/ModuleHelperTests.java
+++ b/src/test/java/com.github.forax.pro.helper/com/github/forax/pro/helper/ModuleHelperTests.java
@@ -1,0 +1,24 @@
+package com.github.forax.pro.helper;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.module.ModuleDescriptor;
+import java.util.Set;
+
+@SuppressWarnings("static-method")
+class ModuleHelperTests {
+  @Test
+  void mergeModules() {
+    ModuleDescriptor sourceModule = ModuleDescriptor.newModule("a.b.c")
+            .requires(Set.of(ModuleDescriptor.Requires.Modifier.TRANSITIVE), "a.b.d")
+            .build();
+    ModuleDescriptor testerModule = ModuleDescriptor.newModule("a.b.c")
+            .requires("org.junit.jupiter.api")
+            .build();
+    ModuleDescriptor mergedModule = ModuleHelper.mergeModuleDescriptor(sourceModule, testerModule);
+    Assertions.assertEquals("a.b.c", mergedModule.name());
+    Assertions.assertTrue(mergedModule.requires().toString().contains("transitive a.b.d"));
+    Assertions.assertTrue(ModuleHelper.moduleDescriptorToSource(mergedModule).contains("requires transitive a.b.d;"));
+  }
+}


### PR DESCRIPTION
Prior to this commit the module source generator used `"Requires::name"` to print a `"requires"` directive line. That missed potentially attached modifiers like `"transitive"` or `"static"`.

Now `"Requires::toString"` is used as it prepends attached modifiers in front the required module name.

(cherry picked from commit 6b44223)