### PR TITLE
Add "formatter" plugin

### DIFF
--- a/format.pro
+++ b/format.pro
@@ -1,0 +1,21 @@
+import static com.github.forax.pro.Pro.*
+
+set("pro.loglevel", "verbose")
+set("pro.exitOnError", true)
+
+// --dry-run
+//   Prints the paths of the files whose contents would change if the formatter were run normally.
+// --set-exit-if-changed
+//       Return exit code 1 if there are any formatting changes.
+
+// set("formatter.rawArguments", list("--dry-run", "--set-exit-if-changed")) // jshell does not exit on error?!
+set("formatter.rawArguments", list("--dry-run"))
+
+// --replace
+//   Send formatted output back to files, not stdout.
+
+// set("formatter.rawArguments", list("--replace"))
+
+run("formatter")
+
+/exit

--- a/plugins/formatter/.gitignore
+++ b/plugins/formatter/.gitignore
@@ -1,0 +1,3 @@
+/deps/
+/libs/
+/target/

--- a/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/com/github/forax/pro/plugin/formatter/ConventionFacade.java
+++ b/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/com/github/forax/pro/plugin/formatter/ConventionFacade.java
@@ -1,0 +1,13 @@
+package com.github.forax.pro.plugin.formatter;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import com.github.forax.pro.api.TypeCheckedConfig;
+
+@TypeCheckedConfig
+public interface ConventionFacade {
+  Path javaHome();
+  List<Path> javaModuleSourcePath();
+  List<Path> javaModuleTestPath();
+}

--- a/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/com/github/forax/pro/plugin/formatter/FormatterConf.java
+++ b/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/com/github/forax/pro/plugin/formatter/FormatterConf.java
@@ -1,0 +1,27 @@
+package com.github.forax.pro.plugin.formatter;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import com.github.forax.pro.api.TypeCheckedConfig;
+import java.util.Optional;
+
+@TypeCheckedConfig
+public interface FormatterConf {
+
+  // Derived from convention
+
+  List<Path> moduleSourcePath();
+  void moduleSourcePath(List<Path> modulePath);
+
+  List<Path> moduleTestPath();
+  void moduleTestPath(List<Path> modulePath);
+
+  // Formatter options
+
+  Optional<List<String>> rawArguments();
+  void rawArguments(List<String> rawArguments);
+
+  Optional<List<Path>> files();
+  void files(List<Path> files);
+}

--- a/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/com/github/forax/pro/plugin/formatter/FormatterPlugin.java
+++ b/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/com/github/forax/pro/plugin/formatter/FormatterPlugin.java
@@ -1,0 +1,85 @@
+package com.github.forax.pro.plugin.formatter;
+
+import static com.github.forax.pro.api.MutableConfig.derive;
+import static com.github.forax.pro.helper.FileHelper.pathFilenameEndsWith;
+import static com.github.forax.pro.helper.FileHelper.walkIfNecessary;
+
+import com.github.forax.pro.api.Config;
+import com.github.forax.pro.api.MutableConfig;
+import com.github.forax.pro.api.Plugin;
+import com.github.forax.pro.api.WatcherRegistry;
+import com.github.forax.pro.api.helper.CmdLine;
+import com.github.forax.pro.api.helper.ProConf;
+import com.github.forax.pro.helper.Log;
+import com.github.forax.pro.helper.Platform;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FormatterPlugin implements Plugin {
+  @Override
+  public String name() {
+    return "formatter";
+  }
+
+  @Override
+  public void init(MutableConfig config) {
+    config.getOrUpdate(name(), FormatterConf.class);
+  }
+  
+  @Override
+  public void configure(MutableConfig config) {
+    FormatterConf formatter = config.getOrUpdate(name(), FormatterConf.class);
+    ConventionFacade convention = config.getOrThrow("convention", ConventionFacade.class);
+
+    derive(formatter, FormatterConf::moduleSourcePath, convention, ConventionFacade::javaModuleSourcePath);
+    derive(formatter, FormatterConf::moduleTestPath, convention, ConventionFacade::javaModuleTestPath);
+  }
+
+  private List<Path> listAllJavaFiles(FormatterConf formatter) {
+    List<Path> pathList = new ArrayList<>();
+    pathList.addAll(formatter.moduleSourcePath());
+    pathList.addAll(formatter.moduleTestPath());
+    return walkIfNecessary(pathList, pathFilenameEndsWith(".java"));
+  }
+  
+  @Override
+  public void watch(Config config, WatcherRegistry registry) {
+    FormatterConf formatter = config.getOrThrow(name(), FormatterConf.class);
+    formatter.moduleSourcePath().forEach(registry::watch);
+    formatter.moduleTestPath().forEach(registry::watch);
+  }
+
+  @Override
+  public int execute(Config config) throws IOException {
+    Log log = Log.create(name(), config.getOrThrow("pro", ProConf.class).loglevel());
+    ConventionFacade convention = config.getOrThrow("convention", ConventionFacade.class);
+    FormatterConf formatter = config.getOrThrow(name(), FormatterConf.class);
+    log.debug(formatter, _formatter -> "config " + _formatter);
+
+    CmdLine cmdLine = new CmdLine();
+    cmdLine.add(convention.javaHome().resolve("bin").resolve(Platform.current().javaExecutableName()));
+    cmdLine.add("--module-path");
+    cmdLine.add(convention.javaHome().resolve("plugins").resolve(name()).resolve("libs"));
+    cmdLine.add("--module");
+    cmdLine.add("google.java.format");
+    // no (raw) arguments will trigger default "format files to stdout" mode
+    formatter.rawArguments().ifPresent(args -> args.forEach(cmdLine::add));
+    log.verbose(cmdLine, CmdLine::toString);
+    // files
+    List<Path> files = formatter.files().orElseGet(() -> listAllJavaFiles(formatter));
+    log.debug(files, fs -> "files:\n" + fs.stream().map(Path::toString).collect(Collectors.joining(" ")));
+    files.forEach(cmdLine::add);
+
+    Process process = new ProcessBuilder(cmdLine.toArguments()).redirectErrorStream(true).start();
+    process.getInputStream().transferTo(System.out);
+    try {
+      return process.waitFor();
+    } catch (InterruptedException e) {
+      // fall-through
+    }
+    return 1; // FIXME
+  }
+}

--- a/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/module-info.java
+++ b/plugins/formatter/src/main/java/com.github.forax.pro.plugin.formatter/module-info.java
@@ -1,0 +1,10 @@
+module com.github.forax.pro.plugin.formatter {
+  requires com.github.forax.pro.api;
+  requires com.github.forax.pro.helper;
+
+  // requires com.google.googlejavaformat;
+  // requires com.google.errorprone;
+
+  provides com.github.forax.pro.api.Plugin
+    with com.github.forax.pro.plugin.formatter.FormatterPlugin;
+}

--- a/src/main/java/com.github.forax.pro.api/com/github/forax/pro/api/impl/DefaultConfig.java
+++ b/src/main/java/com.github.forax.pro.api/com/github/forax/pro/api/impl/DefaultConfig.java
@@ -1,7 +1,6 @@
 package com.github.forax.pro.api.impl;
 
 import java.util.Optional;
-//import java.util.function.BiConsumer;
 
 import com.github.forax.pro.api.Config;
 import com.github.forax.pro.api.MutableConfig;


### PR DESCRIPTION
Based on https://github.com/google/google-java-format -- a program that formats Java source code to comply with Google Java Style:

https://google.github.io/styleguide/javaguide.html

Prior to this commit, the "fake-guava" module baked into pro's internal modules prevented classes to be loaded from the "all-deps" JAR. Using java's auto-module feature makes the format program execution possible.

Use the following configuration to actually format all sources:

```java
  set("formatter.rawArguments", list("--replace"))
  run("formatter")
```